### PR TITLE
Add missing project files to Dockerfile for dependency resolution

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -12,6 +12,8 @@ ENV NUGET_XMLDOC_MODE=skip
 
 # Copy solution file and project files for dependency resolution
 COPY ["NLWebNet.sln", "./"]
+COPY ["Directory.Packages.props", "./"]
+COPY ["NuGet.Config", "./"]
 COPY ["src/NLWebNet/NLWebNet.csproj", "src/NLWebNet/"]
 COPY ["samples/Demo/NLWebNet.Demo.csproj", "samples/Demo/"]
 COPY ["tests/NLWebNet.Tests/NLWebNet.Tests.csproj", "tests/NLWebNet.Tests/"]


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process by ensuring that shared package configuration files are included during dependency resolution.

* Added `Directory.Packages.props` and `NuGet.Config` to the files copied in the Docker build step to ensure proper dependency management.